### PR TITLE
Subquery Task: Add SQL for property ratings and user bookings

### DIFF
--- a/database-adv-script/subqueries.sql
+++ b/database-adv-script/subqueries.sql
@@ -1,0 +1,16 @@
+SELECT *
+FROM properties
+WHERE id IN (
+  SELECT property_id
+  FROM reviews
+  GROUP BY property_id
+  HAVING AVG(rating) > 4.0
+);
+SELECT *
+FROM users u
+WHERE (
+  SELECT COUNT(*)
+  FROM bookings b
+  WHERE b.user_id = u.id
+) > 3;
+


### PR DESCRIPTION
Includes non-correlated and correlated subqueries to meet ALX requirements. Targets AVG ratings over 4.0 and users with more than 3 bookings.